### PR TITLE
Adds auto pagination for octokit

### DIFF
--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,5 +1,6 @@
 class GithubService
   attr_reader :user, :client
+  Octokit.auto_paginate = true
 
   delegate :branches, to: :client
 


### PR DESCRIPTION
## Summary

Adds auto pagination to octokit. In this way we can show all the repos for an organization

TODO: This is not the best way to solve the issue because the gem will request all the pages one after the other. This can hit the API rate limit. We should paginate the page that shows the repos.
