### PR TITLE
Integrates Github pull requests status

### DIFF
--- a/app/controllers/api/v1/metrics_controller.rb
+++ b/app/controllers/api/v1/metrics_controller.rb
@@ -18,7 +18,7 @@ module Api
       end
 
       def metric_params
-        params.fetch(:metric, {}).permit(:branch_name, :name, :value, :url)
+        params.fetch(:metric, {}).permit(:branch_name, :name, :value, :url, :minimum)
       end
     end
   end

--- a/app/controllers/github_pull_requests_controller.rb
+++ b/app/controllers/github_pull_requests_controller.rb
@@ -1,0 +1,11 @@
+class GithubPullRequestsController < ActionController::Base
+  def create
+    case request.env['HTTP_X_GITHUB_EVENT']
+    when 'pull_request'
+      if %w(create reopened opened).include?(params[:action])
+        AnalyzeGithubMetricsStatus.perform_async(params[:pull_request])
+      end
+    end
+    head :ok
+  end
+end

--- a/app/managers/branch_manager.rb
+++ b/app/managers/branch_manager.rb
@@ -1,0 +1,10 @@
+class BranchManager < SimpleDelegator
+  def initialize(branch)
+    super
+  end
+
+  def metrics_status_success?
+    return true unless metrics.present?
+    metrics.all? { |m| !m.minimum || m.value.to_f > m.minimum.to_f }
+  end
+end

--- a/app/models/github_pull_request.rb
+++ b/app/models/github_pull_request.rb
@@ -1,0 +1,19 @@
+class GithubPullRequest
+  attr_reader :pull_request
+
+  def initialize(pull_request)
+    @pull_request = pull_request
+  end
+
+  def full_name
+    pull_request['base']['repo']['full_name']
+  end
+
+  def sha
+    pull_request['head']['sha']
+  end
+
+  def branch
+    pull_request['head']['ref']
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,10 @@ class Project < ActiveRecord::Base
     branches.find_by(default: true)
   end
 
+  def admin_user
+    organization.admin_team.users.first
+  end
+
   def generate_metrics_token
     update(metrics_token: Token.generate_digest([organization.id, id, name]))
   end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -24,4 +24,8 @@ class GithubService
   def get_repo(name)
     client.repo(name)
   end
+
+  def create_status(pull_request, status, options = {})
+    client.create_status(pull_request.full_name, pull_request.sha, status, options)
+  end
 end

--- a/app/workers/analyze_github_metrics_status.rb
+++ b/app/workers/analyze_github_metrics_status.rb
@@ -1,0 +1,41 @@
+class AnalyzeGithubMetricsStatus
+  include Sidekiq::Worker
+  include Rails.application.routes.url_helpers
+  sidekiq_options retry: false
+
+  def perform(pull_request_data)
+    @pull_request = GithubPullRequest.new(pull_request_data)
+    handle_pull_request_status
+  end
+
+  def handle_pull_request_status
+    @project = Project.find_by(github_repo: @pull_request.full_name)
+    return unless @project.present?
+    @branch = @project.branches.find_by(name: @pull_request.branch)
+    return unless @branch.present?
+    @github_service = GithubService.new(@project.admin_user)
+    change_pull_request_status(pull_request_status)
+  end
+
+  def change_pull_request_status(status)
+    @github_service.create_status(
+      @pull_request, status[:key],
+      context: 'CodeStats',
+      # TODO: Add host
+      # target_url: organization_project_branch_url(@project.organization, @project, @branch),
+      description: status[:description]
+    )
+  end
+
+  def pull_request_status
+    BranchManager.new(@branch).metrics_status_success? ? success : failure
+  end
+
+  def success
+    { key: 'success', description: 'All Metrics are OK' }
+  end
+
+  def failure
+    { key: 'failure', description: 'Some Metrics Failed' }
+  end
+end

--- a/app/workers/analyze_github_metrics_status.rb
+++ b/app/workers/analyze_github_metrics_status.rb
@@ -2,6 +2,7 @@ class AnalyzeGithubMetricsStatus
   include Sidekiq::Worker
   include Rails.application.routes.url_helpers
   sidekiq_options retry: false
+  attr_reader :pull_request, :github_service
 
   def perform(pull_request_data)
     @pull_request = GithubPullRequest.new(pull_request_data)
@@ -9,26 +10,26 @@ class AnalyzeGithubMetricsStatus
   end
 
   def handle_pull_request_status
-    @project = Project.find_by(github_repo: @pull_request.full_name)
-    return unless @project.present?
-    @branch = @project.branches.find_by(name: @pull_request.branch)
-    return unless @branch.present?
-    @github_service = GithubService.new(@project.admin_user)
-    change_pull_request_status(pull_request_status)
+    project = Project.find_by(github_repo: pull_request.full_name)
+    return unless project.present?
+    branch = project.branches.find_by(name: pull_request.branch)
+    return unless branch.present?
+    @github_service = GithubService.new(project.admin_user)
+    change_pull_request_status(pull_request_status(project, branch))
   end
 
-  def change_pull_request_status(status)
-    @github_service.create_status(
-      @pull_request, status[:key],
+  def change_pull_request_status(_project, status)
+    github_service.create_status(
+      pull_request, status[:key],
       context: 'CodeStats',
       # TODO: Add host
-      # target_url: organization_project_branch_url(@project.organization, @project, @branch),
+      # target_url: organization_project_branch_url(project.organization, @project, @branch),
       description: status[:description]
     )
   end
 
-  def pull_request_status
-    BranchManager.new(@branch).metrics_status_success? ? success : failure
+  def pull_request_status(branch)
+    BranchManager.new(branch).metrics_status_success? ? success : failure
   end
 
   def success

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Codestats::Application.routes.draw do
     end
   end
 
+  resources :github_pull_requests, only: [:create]
+
 
   # API Endpoints
   api_version(module:  'api/v1', path: { value: 'api/v1' }, defaults: { format: :json }) do

--- a/db/migrate/20160423225633_add_minimum_to_metrics.rb
+++ b/db/migrate/20160423225633_add_minimum_to_metrics.rb
@@ -1,0 +1,5 @@
+class AddMinimumToMetrics < ActiveRecord::Migration
+  def change
+    add_column :metrics, :minimum, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160224011928) do
+ActiveRecord::Schema.define(version: 20160423225633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20160224011928) do
     t.string   "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal  "minimum"
   end
 
   add_index "metrics", ["branch_id"], name: "index_metrics_on_branch_id", using: :btree


### PR DESCRIPTION
## Summary

Now everytime that a pull request is triggered, codestats analyzes all the metrics and if any isn't correct, it marks the pull request as failed. I added a `minimum` column to the metrics. For know it will work only with numeric metrics. It compares the value of the metrics with its minimum value. We can add the type of metric (integer, boolean, etc) later and compare according to that

E.g.:

```
{
   "metric": {
       "branch_name": "test",
       "name" :"coverage",
       "value": "20",
       "minimum": "70"
   }
}
```

will evaluate as invalid.

`TODO:` See how evaluate this only when all the metrics are updated. When the pull request is triggered, probably none of the metrics where calculated yet. I can think of two workarounds:

1 - Trigger this evaluation from the CI. All the metrics must be calculated already
2 - Wait for a webhook of status and see if the context matches `CI`. So if TravisCI finishes for example. It will trigger a `status` webhook with the context `TravisCI`. After that happens, we trigger the evaluate
## Screenshots

<img width="701" alt="screen shot 2016-04-23 at 4 58 31 pm" src="https://cloud.githubusercontent.com/assets/1047402/14764885/75700700-099f-11e6-8e07-6260fe0c465d.png">

<img width="683" alt="screen shot 2016-04-24 at 6 54 18 pm" src="https://cloud.githubusercontent.com/assets/1047402/14770696/0fcdd6a2-0a4e-11e6-847c-b8d3dc2882fd.png">
